### PR TITLE
fix for nuget package spec of DistributedEventBroker

### DIFF
--- a/source/Appccelerate.DistributedEventBroker/Appccelerate.DistributedEventBroker.nuspec
+++ b/source/Appccelerate.DistributedEventBroker/Appccelerate.DistributedEventBroker.nuspec
@@ -17,7 +17,6 @@
     <dependencies>
       <dependency id="Appccelerate.Fundamentals" version="%Appccelerate.Fundamentals%"/>
       <dependency id="Appccelerate.EventBroker" version="%Appccelerate.EventBroker%"/>
-      <dependency id="Appccelerate.DistributedEventBroker" version="%Appccelerate.DistributedEventBroker%"/>
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
DistributedEventBroker: fixed nuget package spec so that it does not contain a dependency cycle
