### PR TITLE
refactored TypeExtensions for simplicity

### DIFF
--- a/source/Appccelerate.Fundamentals/Formatters/TypeExtensions.cs
+++ b/source/Appccelerate.Fundamentals/Formatters/TypeExtensions.cs
@@ -19,8 +19,7 @@
 namespace Appccelerate.Formatters
 {
     using System;
-    using System.Collections.Generic;
-    using System.Globalization;
+    using System.Linq;
 
     /// <summary>
     /// Contains extension methods for Type.
@@ -41,21 +40,9 @@ namespace Appccelerate.Formatters
                 return type.FullName;
             }
 
-            string value = type.FullName.Substring(0, type.FullName.IndexOf('`')) + "<";
-            Type[] genericArgs = type.GetGenericArguments();
-            var list = new List<string>();
-
-            for (int i = 0; i < genericArgs.Length; i++)
-            {
-                value += "{" + i + "},";
-                string s = FullNameToString(genericArgs[i]);
-                list.Add(s);
-            }
-
-            value = value.TrimEnd(',');
-            value += ">";
-            value = string.Format(CultureInfo.InvariantCulture, value, list.ToArray());
-            return value;
+            var partName = type.FullName.Substring(0, type.FullName.IndexOf('`'));
+            var genericArgumentNames = type.GetGenericArguments().Select(arg => arg.FullNameToString());
+            return string.Concat(partName, "<", string.Join(",", genericArgumentNames), ">");
         }
     }
 }


### PR DESCRIPTION
I was pointed to this bit of code by @philippdolder (https://github.com/FakeItEasy/FakeItEasy/pull/106#issuecomment-17155635).

I wrote my own simpler version and I thought I'd contribute it back.

Of course, it could even be a one liner:

``` C#
return type.IsGenericType
    ? string.Concat(type.FullName.Substring(0, type.FullName.IndexOf('`')), "<", string.Join(",", type.GetGenericArguments().Select(arg => arg.FullNameToString())), ">")
    : type.FullName;
```

but that would sacrifice too much readability ;-).
